### PR TITLE
changed velocity invert value

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This package solves the issue with ignition gazebo where the robot moves in the opposite 
 direction than what it is being tol to by the cmd_vel message
 
-I solved this by subscribing to the cmd_vel message, multipling the X componet of the Linear vector by -1
+I solved this by subscribing to the cmd_vel message, multipling the X componet of the Linear vector by -0.25
 and publishing it on a new message called /mammoth/cmd_vel
 
 To get these changes to work in ignition gazebo, I had to change the cmd/vel remapping in the gazebo launch file 

--- a/src/vel_processor.cpp
+++ b/src/vel_processor.cpp
@@ -18,9 +18,9 @@ class VelInverter : public rclcpp::Node
   private:
     void topic_callback(const geometry_msgs::msg::Twist::SharedPtr msg) const
     {
-      msg->linear.x = msg->linear.x * -1;
-      publisher_->publish(*msg);
-    }
+      msg->linear.x = msg->linear.x * -0.25;
+	  	publisher_->publish(*msg);
+		}
     rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr subscription_;
     rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr publisher_;
 };


### PR DESCRIPTION
# Description
During testing, I have found that inverting the velocity does work but the wheel speed is way too fast, so instead of multiplying the x component by -1.0, it multiples it by -0.25

Fixes # (issue)
unsafe traverse of yeti 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
This pull request has been tested by first driving yeti around in ignition gazebo to confirm that the change still allows yeti to drive and it did not break anything. Next, I tested this on the physical yeti to be sure it allowed yeti to traverse at a safe speed